### PR TITLE
Bug 768781, fix the default value of bluetooth CoD to correct value, part 1

### DIFF
--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -64,6 +64,7 @@ PRODUCT_COPY_FILES := \
         system/bluetooth/data/blacklist.conf:system/etc/bluetooth/blacklist.conf \
         system/bluetooth/data/input.conf:system/etc/bluetooth/input.conf \
         system/bluetooth/data/network.conf:system/etc/bluetooth/network.conf \
+        system/bluetooth/data/main.conf:system/etc/bluetooth/main.conf \
         frameworks/base/media/libeffects/data/audio_effects.conf:system/etc/audio_effects.conf
 
 $(call inherit-product-if-exists, frameworks/base/data/fonts/fonts.mk)


### PR DESCRIPTION
Since there is no main.conf under /etc/bluetooth, when we enable bluetooth service, bluetoothd cannot create correct local config on device (/data/misc/bluetoothd/${adapter_address}/config). So we need to modify generic_no_telephony.mk and copy main.conf into device.

For more information, https://bugzilla.mozilla.org/show_bug.cgi?id=768781
