### PR TITLE
Fix SDK locator to include Xcode 10.7 and 10.8

### DIFF
--- a/core/combo/HOST_darwin-x86.mk
+++ b/core/combo/HOST_darwin-x86.mk
@@ -33,16 +33,22 @@ sdks_root := $(platforms_root)/MacOSX.platform/Developer/SDKs
 sdks_old := $(wildcard $sdks_root_old/*.sdk)
 sdks := $(wildcard $sdks_root/*.sdk)
 
-sdk_root := $(sdks_root)/MacOSX10.6.sdk
+sdk_root := $(sdks_root)/MacOSX10.8.sdk
 ifeq ($(wildcard $(sdk_root)),)
-  sdk_root := $(sdks_root_old)/MacOSX10.6.sdk
+  sdk_root := $(sdks_root)/MacOSX10.7.sdk
   ifeq ($(wildcard $(sdk_root)),)
-    sdk_root := $(sdks_root_old)/MacOSX10.5.sdk
+    sdk_root := $(sdks_root)/MacOSX10.6.sdk
     ifeq ($(wildcard $(sdk_root)),)
-      $(warning ***********************************************************)
-      $(warning * No 10.6 or 10.5 SDK found, do you have Xcode installed? *)
-      $(warning ***********************************************************)
-      sdk_root :=
+      sdk_root := $(sdks_root_old)/MacOSX10.6.sdk
+      ifeq ($(wildcard $(sdk_root)),)
+        sdk_root := $(sdks_root_old)/MacOSX10.5.sdk
+        ifeq ($(wildcard $(sdk_root)),)
+          $(warning ***********************************************************)
+          $(warning * No 10.5 -- 10.8 SDK found, do you have Xcode installed? *)
+          $(warning ***********************************************************)
+          sdk_root :=
+        endif
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
The build requires XCode to be installed, and curently raises warnings if it is not able to find XCode 10.5 or 10.6, even if later versions are installed.

This fix looks for 10.7 and 10.8 as well.
