### PR TITLE
Bug 825142 - Do not store the Android ringtones in the system image

### DIFF
--- a/target/product/full_base.mk
+++ b/target/product/full_base.mk
@@ -42,7 +42,7 @@ PRODUCT_PROPERTY_OVERRIDES := \
 PRODUCT_LOCALES := en_US
 
 # Get some sounds
-$(call inherit-product-if-exists, frameworks/base/data/sounds/AllAudio.mk)
+# $(call inherit-product-if-exists, frameworks/base/data/sounds/AllAudio.mk)
 
 # Get the TTS language packs
 $(call inherit-product-if-exists, external/svox/pico/lang/all_pico_languages.mk)


### PR DESCRIPTION
The Android ringtones are part of the platform/frameworks/base project so they cannot be removed from the manifest, however we can prevent them from being packaged by removing the makefile step which includes them.
