### PR TITLE
Bug 830890 - Make mksh be the default shell in the emulator rather than ash

### DIFF
--- a/target/board/generic/BoardConfig.mk
+++ b/target/board/generic/BoardConfig.mk
@@ -28,9 +28,6 @@ BOARD_USES_GENERIC_AUDIO := true
 # no hardware camera
 USE_CAMERA_STUB := true
 
-# Set /system/bin/sh to ash, not mksh, to make sure we can switch back.
-TARGET_SHELL := ash
-
 # Enable dex-preoptimization to speed up the first boot sequence
 # of an SDK AVD. Note that this operation only works on Linux for now
 ifeq ($(HOST_OS),linux)

--- a/target/board/generic_x86/BoardConfig.mk
+++ b/target/board/generic_x86/BoardConfig.mk
@@ -21,9 +21,6 @@ USE_CAMERA_STUB := true
 # customize the malloced address to be 16-byte aligned
 BOARD_MALLOC_ALIGNMENT := 16
 
-# Set /system/bin/sh to ash, not mksh, to make sure we can switch back.
-TARGET_SHELL := ash
-
 # Enable dex-preoptimization to speed up the first boot sequence
 # of an SDK AVD. Note that this operation only works on Linux for now
 ifeq ($(HOST_OS),linux)


### PR DESCRIPTION
ash in the android tree has no [ or test which makes it essentially useless for
non-trivial scripts (like b2g-ps or even run-gdb.sh)

@mwu - pull request as per IRC discussion.
