### PR TITLE
Let extra compiler/linker flags be supplied in the environment.

### DIFF
--- a/core/combo/select.mk
+++ b/core/combo/select.mk
@@ -46,9 +46,9 @@ $(combo_target)HAVE_STRLCPY := 0
 $(combo_target)HAVE_STRLCAT := 0
 $(combo_target)HAVE_KERNEL_MODULES := 0
 
-$(combo_target)GLOBAL_CFLAGS := -fno-exceptions -Wno-multichar
-$(combo_target)RELEASE_CFLAGS := -O2 -g -fno-strict-aliasing
-$(combo_target)GLOBAL_LDFLAGS :=
+$(combo_target)GLOBAL_CFLAGS := -fno-exceptions -Wno-multichar $($(combo_target)EXTRA_GLOBAL_CFLAGS)
+$(combo_target)RELEASE_CFLAGS := -O2 -g -fno-strict-aliasing $($(combo_target)EXTRA_RELEASE_CFLAGS)
+$(combo_target)GLOBAL_LDFLAGS := $($(combo_target)EXTRA_GLOBAL_LDFLAGS)
 $(combo_target)GLOBAL_ARFLAGS := crsP
 
 $(combo_target)EXECUTABLE_SUFFIX :=


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=850041

Names are formed by inserting `EXTRA_` after the `HOST_` or `TARGET_`.
