### PR TITLE
Bug 852583: enable bluetooth on emulator

### DIFF
--- a/target/board/generic/BoardConfig.mk
+++ b/target/board/generic/BoardConfig.mk
@@ -42,3 +42,5 @@ BUILD_EMULATOR_OPENGL := true
 # Build and enable the OpenGL ES View renderer. When running on the emulator,
 # the GLES renderer disables itself if host GL acceleration isn't available.
 USE_OPENGL_RENDERER := true
+
+BOARD_HAVE_BLUETOOTH := true

--- a/target/board/generic_x86/BoardConfig.mk
+++ b/target/board/generic_x86/BoardConfig.mk
@@ -33,3 +33,5 @@ BUILD_EMULATOR_OPENGL := true
 # Build and enable the OpenGL ES View renderer. When running on the emulator,
 # the GLES renderer disables itself if host GL acceleration isn't available.
 USE_OPENGL_RENDERER := true
+
+BOARD_HAVE_BLUETOOTH := true


### PR DESCRIPTION
Set `BOARD_HAVE_BLUETOOTH` to `true` and install emulator specific `init.bt.sh`.
