### PR TITLE
Bug 959019: avoid ADDITIONAL_BUILD_PROPERTIES. r=mwu

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -60,3 +60,7 @@ PRODUCT_COPY_FILES += \
     device/generic/goldfish/init.goldfish.rc:root/init.goldfish.rc \
     device/generic/goldfish/init.goldfish.sh:system/etc/init.goldfish.sh \
     device/generic/goldfish/ueventd.goldfish.rc:root/ueventd.goldfish.rc
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.moz.ril.numclients=9 \
+    $(empty)


### PR DESCRIPTION
See [bug 959019](https://bugzilla.mozilla.org/show_bug.cgi?id=959019).
