### PR TITLE
Bug 916863: Added NFC configuration

### DIFF
--- a/target/board/generic/BoardConfig.mk
+++ b/target/board/generic/BoardConfig.mk
@@ -8,6 +8,9 @@ TARGET_NO_BOOTLOADER := true
 TARGET_NO_KERNEL := true
 TARGET_ARCH := arm
 
+# set ro.product.board
+TARGET_BOOTLOADER_BOARD_NAME := generic
+
 # Note: we build the platform images for ARMv7-A _without_ NEON.
 #
 # Technically, the emulator supports ARMv7-A _and_ NEON instructions, but

--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -47,11 +47,13 @@ PRODUCT_PACKAGES += \
     libOpenglSystemCommon \
     libGLESv2_emulation \
     libGLESv1_enc \
+    nfcd \
     qemu-props \
     qemud \
     camera.goldfish \
     lights.goldfish \
     gps.goldfish \
+    nfc_nci.generic \
     sensors.goldfish
 
 
@@ -62,5 +64,6 @@ PRODUCT_COPY_FILES += \
     device/generic/goldfish/ueventd.goldfish.rc:root/ueventd.goldfish.rc
 
 PRODUCT_PROPERTY_OVERRIDES += \
+    ro.moz.nfc.enabled=true \
     ro.moz.ril.numclients=9 \
     $(empty)


### PR DESCRIPTION
On the emulator, nfcd and nfc_nci.generic have to be build. Also
the variable TARGET_BOOTLOADER_BOARD_NAME has to be set to the
value 'generic', so that libhal will find this value in the env
property 'ro.product.board' when it loads nfc_nci.generic. And NFC
has to be enabled by setting the ro.moz.nfc.enabled.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
