### PR TITLE
Bug 1004195: Handle bootable/recovery/res being a symlink.

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -614,7 +614,7 @@ recovery_kernel := $(INSTALLED_KERNEL_TARGET) # same as a non-recovery system
 recovery_ramdisk := $(PRODUCT_OUT)/ramdisk-recovery.img
 recovery_build_prop := $(INSTALLED_BUILD_PROP_TARGET)
 recovery_binary := $(call intermediates-dir-for,EXECUTABLES,recovery)/recovery
-recovery_resources_common := $(call include-path-for, recovery)/res
+recovery_resources_common := $(call include-path-for, recovery)/res/
 
 # Select the 18x32 font on high-density devices; and the 12x22 font on
 # other devices.  Note that the font selected here can be overridden


### PR DESCRIPTION
Some versions of `bootable/recovery` replace the subdirectory `res` with
a symlink to a copy in `librecovery`, so that FxOS-specific graphics can
be used from the mozilla-b2g fork of that project.  However, this causes
`cp -rf` to try to copy the symlink itself (and fail), and `find` to not
resolve the symlink to find the actual dependencies.

The trailing slash added in this patch fixes these problems.
