### PR TITLE
Bug 1055569

### DIFF
--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -29,6 +29,7 @@ PRODUCT_PACKAGES += \
     atrace \
     libandroidfw \
     libaudiopreprocessing \
+    libaudioroute \
     libaudioutils \
     libbcc \
     libgabi++ \


### PR DESCRIPTION
Bug 1055569 - Add libaudioroute as dependency as required by qcom driver.
