### PR TITLE
Add configuration for armv6 with vfp.

### DIFF
--- a/core/combo/arch/arm/armv6-vfp.mk
+++ b/core/combo/arch/arm/armv6-vfp.mk
@@ -1,0 +1,30 @@
+# Configuration for Linux on ARM.
+# Generating binaries for the ARMv5TE architecture and higher
+#
+ARCH_ARM_HAVE_THUMB_SUPPORT     := true
+ARCH_ARM_HAVE_FAST_INTERWORKING := true
+ARCH_ARM_HAVE_64BIT_DATA        := true
+ARCH_ARM_HAVE_HALFWORD_MULTIPLY := true
+ARCH_ARM_HAVE_CLZ               := true
+ARCH_ARM_HAVE_FFS               := true
+ARCH_ARM_HAVE_VFP               := true
+
+ifeq ($(strip $(TARGET_ARCH_VARIANT_FPU)),)
+TARGET_ARCH_VARIANT_FPU         := vfp
+endif
+ifeq ($(strip $(TARGET_ARCH_VARIANT_CPU)),)
+TARGET_ARCH_VARIANT_CPU         := arm1136jf-s
+endif
+
+# Note: Hard coding the 'tune' value here is probably not ideal,
+# and a better solution should be found in the future.
+#
+arch_variant_cflags := \
+    -mcpu=$(TARGET_ARCH_VARIANT_CPU) \
+    -mfloat-abi=softfp \
+    -mfpu=$(TARGET_ARCH_VARIANT_FPU) \
+    -D__ARM_ARCH_5__ \
+    -D__ARM_ARCH_5T__ \
+    -D__ARM_ARCH_5E__ \
+    -D__ARM_ARCH_5TE__ \
+    -D__ARM_ARCH_6__


### PR DESCRIPTION
The RPi is armv6 but has vfp.  My understanding is that Spidermonkey is much faster with vfp.  This armv6-vfp arch target is only used for the upcoming RPi device (which hopefully is the last armv6 device in the world).  I don't know of any way this config target could affect any other of the platform_build files.

Goal is to merge this into master.  I don't know of any reason create a separate branch for this config, since it's purely additive.

r? @michaelwu 
