### PR TITLE
Bug 1066723 - Create the external storage mount point on the recovery img

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -730,7 +730,7 @@ $(INSTALLED_RECOVERYIMAGE_TARGET): $(MKBOOTFS) $(MKBOOTIMG) $(MINIGZIP) $(RECOVE
 	@echo ----- Making recovery image ------
 	$(hide) rm -rf $(TARGET_RECOVERY_OUT)
 	$(hide) mkdir -p $(TARGET_RECOVERY_OUT)
-	$(hide) mkdir -p $(TARGET_RECOVERY_ROOT_OUT)/etc $(TARGET_RECOVERY_ROOT_OUT)/tmp
+	$(hide) mkdir -p $(TARGET_RECOVERY_ROOT_OUT)/etc $(TARGET_RECOVERY_ROOT_OUT)/tmp $(TARGET_RECOVERY_ROOT_OUT)/storage
 	@echo Copying baseline ramdisk...
 	$(hide) cp -R $(TARGET_ROOT_OUT) $(TARGET_RECOVERY_OUT)
 	@echo Modifying ramdisk contents...


### PR DESCRIPTION
The recovery executable creates the mount point if it doesn't exist, but it creates only the last level. So if the mount point is /storage/sdcard it does a mkdir /storage/sdcard. And that fails if /storage doesn't exist already.
