### PR TITLE
Bug 1122359: add camera.goldfish.jpeg to encode jpeg encoder

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -51,6 +51,7 @@ PRODUCT_PACKAGES += \
     qemu-props \
     qemud \
     camera.goldfish \
+    camera.goldfish.jpeg \
     lights.goldfish \
     gps.goldfish \
     sensors.goldfish
@@ -65,3 +66,5 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.moz.ril.numclients=9 \
     $(empty)
+
+ANDROID_ENABLE_RENDERSCRIPT := false


### PR DESCRIPTION
Add camera.goldfish.jpeg back to emulator and disable renderscript explicitly due to the undefined string in [1].

[1] http://androidxref.com/4.4.2_r1/xref/frameworks/base/libs/hwui/Android.mk#66