### PR TITLE
 Bug 1124567: Disable Gaia screen timeout

### DIFF
--- a/target/board/generic/BoardConfig.mk
+++ b/target/board/generic/BoardConfig.mk
@@ -88,3 +88,6 @@ CONFIG_EAP_TLS := true
 WIFI_DRIVER_FW_PATH_AP := "ap"
 WIFI_DRIVER_FW_PATH_STA := "sta"
 WIFI_DRIVER_FW_PATH_PARAM := "/data/misc/wifi/fake_fwpath"
+
+# Bug 1124567: Disable Gaia screen timeout
+BOARD_GAIA_MAKE_FLAGS := SCREEN_TIMEOUT=0


### PR DESCRIPTION
 This patch disables Gaia's screen timeout on 'emulator-kk'. The fix
 is required to make the emulator start up reliably.