### PR TITLE
Bug 1116360 - Set ro.moz.ril.query_icc_count.

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -65,6 +65,7 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.moz.ril.numclients=9 \
+    ro.moz.ril.query_icc_count=true \
     $(empty)
 
 ANDROID_ENABLE_RENDERSCRIPT := false


### PR DESCRIPTION
Please see [bug 1116360](https://bugzilla.mozilla.org/show_bug.cgi?id=1116360).

Setting this property to true enables support for reading the number of remaining unlock retries for an ICC lock on the emulator.