### PR TITLE
Bug 1134821: Set Bluetooth backend to 'bluetoothd'

### DIFF
--- a/target/product/full_base.mk
+++ b/target/product/full_base.mk
@@ -44,7 +44,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES := \
     ro.com.android.dateformat=MM-dd-yyyy \
     ro.config.ringtone=Ring_Synth_04.ogg \
-    ro.config.notification_sound=pixiedust.ogg
+    ro.config.notification_sound=pixiedust.ogg \
+    ro.moz.bluetooth.backend=bluetoothd
 
 # Put en_US first in the list, so make it default.
 PRODUCT_LOCALES := en_US


### PR DESCRIPTION
This change enables bluetoothd for all custom-build images. Users with
regular base images will default to the Bluedroid backend.