### PR TITLE
Bug 1139331 - Fix using ITEMS in setPermission for nexus-5-l

### DIFF
--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -331,7 +331,7 @@ class Item:
 
       recurse(self, (-1, -1, -1, -1, None, None))
     else:
-      if self.name in self.ITEMS:
+      if self.name in self.itemset.ITEMS:
         script.SetPermissions("/"+self.name, self.uid, self.gid,
                               self.mode, self.selabel, self.capabilities)
 


### PR DESCRIPTION
For nexus-5-l, ota_from_target_files using ItemSet and Item to
replace Item. ITEMS is moved from Item to ItemSet. Fix usage in
setPermission.