### PR TITLE
Bug 1181481 - Build standalone emulator host binary

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -136,9 +136,6 @@ $(warning ************************************************************)
 $(error Directory names containing spaces not supported)
 endif
 
-# For B2G, Emulators need to be built locally.
-BUILD_EMULATOR ?= true
-
 ifndef BUILD_EMULATOR
   # Emulator binaries are now provided under prebuilts/android-emulator/
   BUILD_EMULATOR := false

--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -20,21 +20,7 @@
 
 # Host modules
 PRODUCT_PACKAGES += \
-    emulator \
-    emulator-arm \
-    emulator-mips \
-    emulator-x86 \
-    emulator64-arm \
-    emulator64-mips \
-    emulator64-x86 \
-    lib64EGL_translator \
-    lib64GLES_CM_translator \
-    lib64GLES_V2_translator \
-    lib64OpenglRender \
-    libEGL_translator \
-    libGLES_CM_translator \
-    libGLES_V2_translator \
-    libOpenglRender \
+    emulator-standalone \
     mksdcard
 
 # Device modules


### PR DESCRIPTION
Please see [Bug 1181481](https://bugzilla.mozilla.org/show_bug.cgi?id=1184418).