### PR TITLE
Bug 1163483 - Enable only 2 RIL services on emulator-l

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -18,6 +18,8 @@
 # emulator-related modules to PRODUCT_PACKAGES.
 #
 
+EMULATOR_MULTI_SIM := 2
+
 # Host modules
 PRODUCT_PACKAGES += \
     emulator-standalone \
@@ -51,6 +53,6 @@ PRODUCT_COPY_FILES += \
     device/generic/goldfish/ueventd.goldfish.rc:root/ueventd.goldfish.rc
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.moz.ril.numclients=9 \
+    ro.moz.ril.numclients=$(EMULATOR_MULTI_SIM) \
     ro.moz.ril.query_icc_count=true \
     $(empty)


### PR DESCRIPTION
Please see [bug 1163483](https://bugzilla.mozilla.org/show_bug.cgi?id=1163483).
