### PR TITLE
Bug 1134982 - Enable ro.moz.ril.query_icc_count on emulator-l

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -52,4 +52,5 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.moz.ril.numclients=9 \
+    ro.moz.ril.query_icc_count=true \
     $(empty)


### PR DESCRIPTION
Setting this property to true enables support for reading the number
of remaining unlock retries for an ICC lock on the emulator.

Please see [bug 1134982](https://bugzilla.mozilla.org/show_bug.cgi?id=1134982).
