### PR TITLE
Bug 1193234 - Enable only 2 RIL services on emulator-kk

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -68,7 +68,7 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.moz.nfc.enabled=true \
-    ro.moz.ril.numclients=9 \
+    ro.moz.ril.numclients=2 \
     ro.moz.ril.query_icc_count=true \
     $(empty)
 


### PR DESCRIPTION
Please see [bug 1193234](https://bugzilla.mozilla.org/show_bug.cgi?id=1193234).
