### PR TITLE
Bug 1196630 - set mozSettings value "screen.timeout" of the profile-to-test to 0 so the screen never sleeps

### DIFF
--- a/target/board/generic_x86/BoardConfig.mk
+++ b/target/board/generic_x86/BoardConfig.mk
@@ -56,3 +56,6 @@ CONFIG_EAP := true
 CONFIG_EAP_PEAP := true
 CONFIG_EAP_TTLS := true
 CONFIG_EAP_TLS := true
+
+# Bug 1196630: Disable Gaia screen timeout
+BOARD_GAIA_MAKE_FLAGS := SCREEN_TIMEOUT=0


### PR DESCRIPTION
Please see [bug 1196630](https://bugzilla.mozilla.org/show_bug.cgi?id=1196630).
