### PR TITLE
Bug 1209096 - Fork CyanogenMod recovery to B2G for maximum device compatibility

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -862,11 +862,10 @@ $(INSTALLED_RECOVERYIMAGE_TARGET): $(MKBOOTFS) $(MKBOOTIMG) $(MINIGZIP) $(RECOVE
 		$(recovery_fstab) \
 		$(RECOVERY_INSTALL_OTA_KEYS)
 	@echo ----- Making recovery image ------
-	$(hide) rm -rf $(TARGET_RECOVERY_OUT)
 	$(hide) mkdir -p $(TARGET_RECOVERY_OUT)
 	$(hide) mkdir -p $(TARGET_RECOVERY_ROOT_OUT)/etc $(TARGET_RECOVERY_ROOT_OUT)/tmp
 	@echo Copying baseline ramdisk...
-	$(hide) cp -R $(TARGET_ROOT_OUT) $(TARGET_RECOVERY_OUT)
+	$(hide) rsync -aq $(TARGET_ROOT_OUT)/* $(TARGET_RECOVERY_ROOT_OUT)/
 	@echo Modifying ramdisk contents...
 	$(hide) rm -f $(TARGET_RECOVERY_ROOT_OUT)/init*.rc
 	$(hide) cp -f $(recovery_initrc) $(TARGET_RECOVERY_ROOT_OUT)/


### PR DESCRIPTION
CyanogenMod has a nice, developer friendly recovery. However AOSP
recovery is a jealous beast. It rudely deletes CM recovery after
it has built, copying itself in its place.

We just cant let this continue, we live in world of equality.

Signed-off-by: Adam Farden adam@farden.cz
