### PR TITLE
Bug 1299497 - Build fails with "unsupported reloc 43" errors. r=gerar…

### DIFF
--- a/core/clang/HOST_x86_common.mk
+++ b/core/clang/HOST_x86_common.mk
@@ -8,6 +8,7 @@ ifeq ($(HOST_OS),linux)
 CLANG_CONFIG_x86_LINUX_HOST_EXTRA_ASFLAGS := \
   --gcc-toolchain=$($(clang_2nd_arch_prefix)HOST_TOOLCHAIN_FOR_CLANG) \
   --sysroot=$($(clang_2nd_arch_prefix)HOST_TOOLCHAIN_FOR_CLANG)/sysroot \
+  -B$($(clang_2nd_arch_prefix)HOST_TOOLCHAIN_FOR_CLANG)/x86_64-linux/bin \
   -no-integrated-as
 
 CLANG_CONFIG_x86_LINUX_HOST_EXTRA_CFLAGS := \


### PR DESCRIPTION
…d-majax

Build fails with "unsupported reloc 43" errors. As explained in https://oopsmonk.github.io/blog/2016/06/07/android-build-error-on-ubuntu-16-04-lts:
The older prebuilt toolchain have some problems with newer version of ‘as’ in the native environment.
This error will show up when your environment is Ubuntu 16.04 and AOSP before May 7, 2106.
